### PR TITLE
Add missing English post translations, fix series order conflict

### DIFF
--- a/data/posts/en/game-collection-part-1.mdx
+++ b/data/posts/en/game-collection-part-1.mdx
@@ -1,0 +1,100 @@
+---
+title: Favorite Steam games collection
+date: 2026-03-17
+tags: [game, steam]
+summary: Introducing the Steam games I've played and loved
+image:
+authors: [default]
+---
+
+
+## 1. Oxygen Not Included
+![thumbnail_oxygen_not_included](/posts/steam_game/thumbnail_oxygen_not_included.png)
+Oxygen Not Included is a simulation-management game by Klei Entertainment, where
+you control a group of "Duplicants" stranded deep inside an asteroid. Your task
+sounds simple but is anything but: keep them alive. In this unforgiving world,
+everything is a precious resource:
+- 🌬 Oxygen is always in short supply
+- 💧 Water has to be filtered and recycled
+- 🔥 Heat can destroy your entire base
+- 🦠 Germs quietly threaten your colonists' lives
+- ⚙️ Automation and wiring need to be optimized to keep the base running smoothly
+
+The appeal of the game lies in having to calculate every little detail, from base
+layout and gas management to research and colony expansion. Every small decision
+can trigger an unexpected chain reaction. If you enjoy games that demand logical
+thinking, creativity, and constant "firefighting", Oxygen Not Included will
+definitely hook you.
+
+## 2. Core Keeper
+![thumbnail_core_keeper](/posts/steam_game/thumbnail_core_keeper.png)
+You wake up in a dark cave, surrounded by cold stone walls and a strange blue
+glow radiating from an artifact floating in mid-air - the Core. There's no exit,
+no instructions. Just you, a few basic tools, and a vast underground world
+waiting to be explored. Core Keeper is a survival-adventure game in a pixel-art
+style, where you play an explorer teleported into a mysterious underground
+realm. From here, you begin a journey of digging, building, fighting, and
+unraveling the power of the Core - the heart of this world.
+
+Unlike typical sandbox games, Core Keeper offers a procedurally generated cave
+system where every step can lead to a new secret:
+- 💎 Resource gathering: mine, collect minerals, craft tools and weapons.
+- 🏠 Base building: build a shelter, decorate it your way, and optimize your living space.
+- 🌱 Farming & cooking: grow crops, raise animals, and cook dishes to boost stats and recover.
+- ⚔️ Boss fights: face giant creatures like Glurch, Ghorm, and the Hive Mother, each guarding a piece of the Core's secret.
+- 🤝 Play with friends: co-op support for up to 8 players to explore and build together.
+
+Core Keeper doesn't demand fast reflexes or complex combat skills. Instead, it
+focuses on exploration, creativity, and resource management. You can spend hours
+just designing your base, experimenting with recipes, or finding your way to new
+lands.
+
+## 3. Dead Cells
+![thumbnail_dead_cells](/posts/steam_game/thumbnail_dead_cells.png)
+Dead Cells is a 2D action game blending rogue-lite and Metroidvania elements,
+where every move, every slash, and every death contributes to a journey that
+never repeats itself. Developed by Motion Twin, the game quickly became a
+phenomenon thanks to its fast-paced gameplay, gorgeous pixel art, and
+addictively brutal difficulty.
+
+Main highlights:
+- ⚔️ Fast-paced combat - smooth, precise, and deeply satisfying
+- 🛡️ A rich arsenal - hundreds of combinations to build your own playstyle
+- 🌄 A vivid pixel-art world - each area has its own mood and secrets
+- 👹 Tough but exhilarating bosses - every fight is a genuine test of skill
+- 🔁 Die to grow stronger - every death opens a new, harder, but more compelling run
+
+Dead Cells takes you through decaying prisons, dense jungles, dangerous towers,
+and monster-filled castles. Every run is randomly generated, so you never know
+what's waiting ahead. That unpredictability is exactly what makes it so hard to
+put down.
+
+## 4. ORX
+![thumbnail_ORX](/posts/steam_game/thumbnail_ORX.png)
+ORX is a tower-defense strategy game combined with deckbuilding, where you use
+cards to expand your territory, construct buildings, and fend off relentless
+waves of ORX monsters. The game draws inspiration from Carcassonne and Slay the
+Spire, resulting in gameplay that feels both familiar and full of challenge.
+
+Highlights of ORX:
+- 🧱 A unique blend of deckbuilding and tower defense.
+- 🃏 Over 300 cards to build, upgrade, and summon troops.
+- 👹 Many types of ORX monsters, growing stronger with each wave.
+- 🔄 Roguelike elements keep every run fresh and full of surprises.
+- 🎨 Dark fantasy art with an isometric view that's easy to read for tactical planning
+
+## 5. Against the Storm
+![thumbnail_against_the_storm](/posts/steam_game/thumbnail_against_the_storm.png)
+Against the Storm is a city-building strategy game with roguelite elements,
+where you lead several different races to build temporary settlements in a
+world constantly threatened by the Eternal Storm.
+
+The game stands out thanks to:
+- 🌲 Fast-paced city-building, with every map feeling new and challenging
+- 🌀 A harsh weather system, especially the Storm season
+- 👥 Multiple races, each with their own needs and skills
+- 🎲 Roguelite elements - maps, resources, and buildings change every run
+- 🏰 Capital upgrades that give a real sense of long-term progress
+
+If you like city builders but want something fast-paced, tactical, and always
+fresh, Against the Storm is well worth trying.

--- a/data/posts/en/how-to-install-gurobi.mdx
+++ b/data/posts/en/how-to-install-gurobi.mdx
@@ -1,0 +1,55 @@
+---
+title: How to install Gurobi
+date: 2024-09-28
+tags: [gurobi, programming]
+summary: A guide to installing Gurobi and requesting a license
+image:
+authors: [default]
+---
+
+import { Twemoji } from '@/components/common/Twemoji.tsx'
+
+For anyone new to the [Gurobi](https://www.gurobi.com/) solver, and for students
+taking the **Optimization** course at the Faculty of Mathematics, Mechanics and
+Informatics, VNU University of Science.
+
+**Step 1:** Download Gurobi from this [link](https://www.gurobi.com/downloads/gurobi-software/)
+(scroll down to find the download files) and install it.
+![gurobi_install](/posts/how_to_install_gurobi/gurobi_0.png)
+
+**Step 2:** Register a Gurobi account
+
+**Step 3:** Request a Gurobi license.
+  - Log in to [Gurobi](https://www.gurobi.com/)
+  - Select `My account`
+  ![gurobi_install](/posts/how_to_install_gurobi/gurobi_1.png)
+
+  - Select `Review your current licenses` under `licenses`
+  ![gurobi_install](/posts/how_to_install_gurobi/gurobi_2.png)
+  - Go to `Request` and pick the license you want. If you're just starting out, choose `Gurobi Limited license`
+  ![gurobi_install](/posts/how_to_install_gurobi/gurobi_3.png)
+  - Under `licenses`, you'll see the list of your licenses
+
+**Step 4:** Activate the license on your computer
+  - In the `licenses` section from the step above, pick the license you want and click the icon shown below
+  ![gurobi_install](/posts/how_to_install_gurobi/gurobi_4.png)
+  - Copy the line that looks like `grbgetkey [key]`
+  ![gurobi_install](/posts/how_to_install_gurobi/gurobi_5.png)
+  - Open a `Terminal` (`PowerShell` or `Command Prompt` on `Windows`) and run that line. If you get the
+  result shown below, the installation was successful
+  ![gurobi_install](/posts/how_to_install_gurobi/gurobi_6.png)
+
+**Step 5:** Install `gurobipy`
+  open a `Terminal` (`PowerShell` or `Command Prompt` on `Windows`) and run
+  ```terminal
+  pip install gurobipy
+  ```
+
+Above are the steps to install Gurobi and activate a free license. This license
+can only solve small-sized problems (which is enough for the **Optimization**
+course at the Faculty of Mathematics, Mechanics and Informatics, VNU University
+of Science). For larger problems, you'll need to purchase a paid license or
+request an academic license (see how to request an academic license at
+[quanhoang-pm](https://quanhoang-pm.github.io/programming/requesting-gurobi-academic-license/)).
+
+Happy installing! <Twemoji emoji="clinking-beer-mugs" />

--- a/data/posts/en/logic-puzzle-modeling/logic-puzzle-modeling-a-puzzle-a-day.mdx
+++ b/data/posts/en/logic-puzzle-modeling/logic-puzzle-modeling-a-puzzle-a-day.mdx
@@ -1,0 +1,99 @@
+---
+title: Modeling A puzzle a day puzzle
+date: 2026-07-23
+series:
+  order: 7
+  title: Modeling logic puzzles
+tags: [modeling, math, MILP, programing, python]
+summary: Modeling and solving the A puzzle a day puzzle using mixed-integer linear programming.
+image: /posts/logic_puzzle_modeling/a_puzzle_a_day.png
+authors: [default]
+---
+
+import { Twemoji } from '@/components/common/Twemoji.tsx'
+
+## 1. Introduction
+
+A puzzle a day is a packing puzzle described as follows: given a calendar-shaped
+board of size $7 \times 7$ cells, where the 43 valid cells are split into 12
+cells holding month abbreviations (the top 2 rows), 31 cells holding the day
+numbers (the remaining 5 rows), and 6 remaining cells in the top-right and
+bottom-right corners that don't belong to the board. The player has 8 polyomino
+pieces (each made of 5 or 6 unit squares) and must place all of them on the
+board, rotating and flipping each piece as needed, satisfying:
+- Each piece is used exactly once
+- No two pieces overlap
+- Every valid cell on the board is covered, **except exactly 2 cells** - the
+cell for the month and the cell for the day to be displayed
+
+The two cells left uncovered are exactly "today's date" that the puzzle
+displays - which is also why this puzzle is called A puzzle a day, since
+almost every day of the year has a (or several) different arrangement to
+discover.
+
+Below is an example solution for July 23rd
+
+![a_puzzle_a_day_example](/posts/logic_puzzle_modeling/a_puzzle_a_day.png)
+
+## 2. Modeling puzzle
+
+- $\Omega$ is the set of coordinates of the valid cells on the board (43 cells, after removing the 6 cells that don't belong to the calendar)
+- $c_m \in \Omega$ is the cell corresponding to the month to display
+- $c_d \in \Omega$ is the cell corresponding to the day to display
+- $\mathcal{P} = \{O, P, L, C, V, S, J, F\}$ is the set of names of the 8 pieces
+used to cover the board, each piece having a fixed shape made of 5 or 6
+adjacent unit squares
+- For each piece $p \in \mathcal{P}$, generate every rotated ($0°, 90°, 180°,
+270°$) and mirrored variant of the piece, then for each variant, scan every
+translated position on the board and keep only the positions where the whole
+piece fits inside $\Omega$. Let $K_p$ be the set of all valid configurations
+(placements) obtained for piece $p$, where each configuration $k \in K_p$
+corresponds to a set of cells $S(p, k) \subset \Omega$ occupied by piece $p$
+when placed according to that configuration
+
+### 2.1. Decision variables
+
+For each piece $p \in \mathcal{P}$ and each configuration $k \in K_p$, define variable $x(p, k)$ such that
+```math
+x(p, k) = \begin{cases}
+  1 & \text{if piece } p \text{ is placed according to configuration } k \\
+  0 & \text{otherwise}
+\end{cases}
+```
+
+### 2.2. Constraints
+
+- Each piece is placed according to exactly one configuration
+```math
+\sum\limits_{k \in K_p}{x(p, k)} = 1, \forall p \in \mathcal{P}
+```
+
+- Each valid cell is covered the required number of times: ordinary cells must
+be covered by exactly one piece, while the month cell $c_m$ and the day cell
+$c_d$ must not be covered by any piece
+```math
+\sum\limits_{p \in \mathcal{P}}{\sum\limits_{k \in K_p : c \in S(p, k)}{x(p, k)}} = \begin{cases}
+  0 & \text{if } c \in \{c_m, c_d\} \\
+  1 & \text{otherwise}
+\end{cases}
+\\ \forall c \in \Omega
+```
+
+### 2.3. Objective function
+
+Just like [Troix](/en/blog/logic-puzzle-modeling-troix), this is a feasibility
+problem: we only need to find one way to place the 8 pieces that satisfies all
+the constraints, without minimizing or maximizing anything. So the objective
+function is simply set to a constant (I chose 0).
+
+## 3. Conclusion
+
+This is a model of the well-known calendar packing puzzle called A puzzle a
+day. With this model, you can plug in any date and immediately get a valid
+arrangement of the 8 pieces for that day, instead of having to figure it out by
+hand.
+
+*The Python code for A puzzle a day modeling is available at
+[Tung-hehe](https://github.com/Tung-hehe/logic-puzzles-solver/blob/main/src/puzzles/a_puzzle_a_day.py)*
+
+Happly modeling! <Twemoji emoji="clinking-beer-mugs" />

--- a/data/posts/en/logic-puzzle-modeling/logic-puzzle-modeling-slitherlink.mdx
+++ b/data/posts/en/logic-puzzle-modeling/logic-puzzle-modeling-slitherlink.mdx
@@ -1,0 +1,127 @@
+---
+title: Modeling Slitherlink puzzle
+date: 2024-11-29
+series:
+  order: 6
+  title: Modeling logic puzzles
+tags: [modeling, math, MILP, programing, python]
+summary: Modeling and solving the Slitherlink puzzle using mixed-integer linear programming.
+image: /posts/logic_puzzle_modeling/slitherlink.png
+authors: [default]
+---
+
+import { Twemoji } from '@/components/common/Twemoji.tsx'
+
+## 1. Introduction
+
+Slitherlink is a logic puzzle with the following rules:
+- Connect the dots on a grid, horizontally or vertically, to form a single closed loop, without crossings or branches
+- Some cells, each formed by 4 dots on the grid, are pre-filled with a number smaller than 4, indicating how many of that cell's edges must be part of the loop (empty cells may have any number of surrounding edges)
+
+*Note: an edge is defined as a connection between 2 adjacent dots*
+
+Below is an example of a 7×7 Slitherlink puzzle and its solution
+
+![slitherlink_example](/posts/logic_puzzle_modeling/slitherlink.png)
+
+
+## 2. Modeling puzzle
+
+- $n_R$ is the number of rows in the grid
+- $n_C$ is the number of columns in the grid
+- $F$: the set of cells that have a number inside
+- $L(i, j)$: the number filled inside cell $(i, j)$
+- $N_H(i, j)$: the horizontal edges connected to point $(i, j)$
+- $N_V(i, j)$: the vertical edges connected to point $(i, j)$
+
+### 2.1. Decision variables
+
+To solve this problem we need to define a variable for each edge on the grid
+and each point on the grid, as follows
+- For each horizontal edge $(i, j)$ on the grid ($0 \leq i < n_R + 1, 0 \leq j < n_C$), define variable $h(i, j)$ such that
+```math
+h(i, j) = \begin{cases}
+  1 & \text{if edge } (i, j) \text{ is part of the loop} \\
+  0 & \text{otherwise}
+\end{cases}
+```
+
+- For each vertical edge $(i, j)$ on the grid ($0 \leq i < n_R, 0 \leq j < n_C + 1$), define variable $v(i, j)$ such that
+```math
+v(i, j) = \begin{cases}
+  1 & \text{if edge } (i, j) \text{ is part of the loop} \\
+  0 & \text{otherwise}
+\end{cases}
+```
+
+- For each point $(i, j)$ on the grid ($0 \leq i < n_R + 1, 0 \leq j < n_C + 1$), define variable $p(i, j)$ such that
+```math
+p(i, j) = \begin{cases}
+  1 & \text{if point } (i, j) \text{ is part of the loop} \\
+  0 & \text{otherwise}
+\end{cases}
+```
+
+### 2.2. Constraints
+
+- The number of edges surrounding a cell equals the number filled in that cell (except for empty cells)
+```math
+h(i, j) + h(i + 1, j) + v(i, j) + v(i, j + 1) = L(i, j), \\ \forall (i, j) \in F
+```
+
+- The points must connect into a single closed loop, without crossings or branches.
+
+  Modeling this condition directly is far from easy, so here we model part of
+the condition and use an algorithm described in section [2.4](/en/blog/logic-puzzle-modeling-slitherlink#24-solving-the-problem)
+to solve the rest. Specifically, we model the condition: "the points must
+connect into some number of disjoint, closed, non-crossing, non-branching
+loops".
+
+```math
+\sum\limits_{(s, t) \in N_H(i, j)}{h(s, t)} + \sum\limits_{(s, t) \in N_V(i, j)}{v(s, t)} = 2 \cdot p(i, j), \\ \forall 0 \leq i < n_R + 1, 0 \leq j < n_C + 1
+```
+
+### 2.3. Objective function
+
+This problem does not have an objective function, as we are not aiming to
+minimize or maximize any value. Our goal is simply to find a feasible
+solution. Technically, when programming, we can set the objective function to
+a constant (I often choose 0).
+
+### 2.4. Solving the problem
+
+Solving the model above gives us a solution that satisfies almost every
+condition of the problem, except that instead of a single loop, we may end up
+with several disjoint loops. To fix this, we use the following algorithm:
+```python
+BEGIN Slitherlink
+    initialize model M;
+    solve M;
+    S := solution of M;
+    WHILE (S still contains more than 1 loop)
+        add constraints to cut every loop in S;
+        solve M;
+        S := solution of M;
+    END
+    Return S;
+END
+```
+The constraint used to cut a loop is modeled as follows
+```math
+\sum\limits_{(i, j) \in H_c} h(i, j) + \sum\limits_{(i, j) \in V_c} v(i, j) \leq 1, \\ \forall c \in C
+```
+Where $C$ is the set of all loops obtained after one solve, $H_c$ is the set of
+all horizontal edges in loop $c$, and $V_c$ is the set of all vertical edges in
+loop $c$.
+
+## 3. Conclusion
+
+The highlight of this puzzle is the loop-cutting algorithm - a fun idea for
+dealing with problems that are hard to model directly: solve several
+approximate models one after another until you land on the correct solution.
+
+*For more Slitherlink puzzles and variations, please refer to [Krazydad](https://krazydad.com/slitherlink//).
+The Python code for Slitherlink modeling is available at
+[Tung-hehe](https://github.com/Tung-hehe/logic-puzzles-solver/blob/main/src/puzzles/slitherlink.py).*
+
+Happly modeling! <Twemoji emoji="clinking-beer-mugs" />

--- a/data/posts/en/love-letter-project.mdx
+++ b/data/posts/en/love-letter-project.mdx
@@ -1,0 +1,76 @@
+---
+title: Love Letter - a personalized love letter generator
+date: 2026-07-23
+tags: [project, python]
+summary: Introducing Love Letter - a tool for generating beautiful, personalized love letters that look great on both mobile and desktop.
+image: /posts/love_letter_project/love_letter_project.png
+authors: [default]
+---
+
+import { Twemoji } from '@/components/common/Twemoji.tsx'
+
+Unlike the math modeling posts you usually see on this blog, this one is a
+small gift: a tool that turns a few lines of your feelings into a
+beautiful-looking letter.
+
+![love_letter_preview](/posts/love_letter_project/love_letter_project.png)
+
+## Why I made this
+
+Something that happened recently affected me quite deeply - it was the first
+time I went through such a strong emotional experience. It made someone as
+dry and rational as me realize that feelings had been neglected for far too
+long. I spent quite a while thinking about it, and realized I wasn't lacking
+in feelings at all, nor in love for the people I care about. What I lacked was
+simply a way to express it, so I started looking for one.
+
+My feelings usually aren't easy to say out loud, but writing them down, with
+some preparation, is a different story. Still, a plain text message felt too
+ordinary, so I chose to write a letter instead. The problem was, after years
+of studying and working while just typing code, my handwriting has gotten
+really bad - and bad handwriting pretty much cuts a letter's value in half 😂.
+
+So I built this project to fix that: just prepare the content, and the
+project outputs **a single `.html` file** - send it through any chat app, and
+the recipient just needs to tap it to view it right away. It can also be
+customized by theme, to make the "letter" feel even more special.
+
+## 8 "moods" to choose from
+
+The project ships with 8 templates, each with its own color palette and mood:
+Warm, Passionate, Longing, Sweet, Peaceful, Sorry, Pouty, and Confession. The
+letter's content stays the same - just switch templates to get a completely
+different vibe.
+
+## A few small details I'm quite proud of
+
+- **Envelope-opening effect**: the letter first appears as a sealed envelope;
+tapping/clicking it opens the flap, then the letter slides up.
+- **Automatic pagination for long letters**: letters longer than 3 paragraphs
+are automatically split into multiple "pages" like a book - swipe left/right
+on mobile or click the arrows on desktop to turn pages, instead of scrolling
+through one long letter.
+- **No external fonts**: every template uses fonts already available on the
+system (San Francisco, Roboto...) instead of loading fonts from Google Fonts.
+The reason is that the built-in web viewers inside some messaging apps (like
+Messenger) can ignore custom fonts and render text with their own font
+instead - complex Vietnamese diacritics (ư, ơ...) are especially prone to
+breaking in that situation, so relying directly on the operating system's
+fonts is the only way to guarantee correct rendering everywhere.
+
+## How to use it
+
+Get Python ready, install the `jinja2` and `pyyaml` libraries, write your
+letter's content into a YAML file, then run
+
+```bash
+python generate.py
+```
+
+The script will ask you to pick a content file and a template, then output a
+single `.html` file in `output/` - send that file to the recipient and you're
+done.
+
+*Code available at [Tung-hehe/love-letter](https://github.com/Tung-hehe/love-letter)*
+
+Happy coding, and may your feelings be fully received through every letter! <Twemoji emoji="love-letter" />

--- a/data/posts/en/modeling-THPTQG-2025.mdx
+++ b/data/posts/en/modeling-THPTQG-2025.mdx
@@ -1,0 +1,85 @@
+---
+title: Modeling the number-filling problem in the 2025 THPTQG exam
+date: 2026-03-12
+tags: [modeling, math, LP]
+summary: Modeling the number-filling problem from the 2025 THPTQG exam.
+image:
+authors: [default]
+---
+
+import { Twemoji } from '@/components/common/Twemoji.tsx'
+
+## 1. Introduction
+
+In the 2025 THPTQG exam (Vietnam's national high school graduation exam), the
+Math paper included a rather novel number-filling problem that surprised many
+students. This problem also hides quite a bit of interesting structure - in
+this post, we'll model it together to see exactly where that interest lies.
+
+![math-THPTQG-2025](/posts/math-THPTQG-2025.png)
+
+The original problem asks for the probability that a random arrangement
+satisfies an arithmetic-progression requirement. In this post, however, we
+only care about finding every arrangement that satisfies the requirement.
+
+So the problem can be restated in general form as follows: choose $2n$ numbers
+out of the $n^2$ numbers $\{1, 2, 3, ..., n^2\}$ and arrange them into a
+sequence at positions $\{0, 1, ..., n - 1\}$ such that every triple of numbers
+at positions $(2k, 2k + 1, 2k + 2)$ for $\forall k \in \{0, 1, ..., n - 2\}$
+forms an arithmetic progression, and the triple at positions $(2n - 2, 2n - 1,
+0)$ also forms an arithmetic progression.
+
+## 2. Modeling the problem
+
+### 2.1. Decision variables
+
+For each position $i \in \{0, 1, ..., n - 1\}$ and each value $j \in \{1, 2, 3, ..., n^2\}$, define variable $x(i, j)$ such that
+```math
+x(i, j) = \begin{cases}
+    1 & \text{if position } i \text{ is filled with number } j \\
+    0 & \text{otherwise}
+\end{cases}
+```
+
+### 2.2. Constraints
+
+- Each position must be filled with a number
+```math
+\sum\limits_{j = 1}^{n^2}{x(i, j)} = 1, \\ \forall i \in \{0, 1, ..., n - 1\}
+```
+
+- Each number can be used at most once
+```math
+\sum\limits_{i = 0}^{n - 1}{x(i, j)} \leq 1, \\ \forall j \in \{1, 2, 3, ..., n^2\}
+```
+
+- Each required triple of positions forms an arithmetic progression
+```math
+\sum\limits_{j = 1}^{n^2}{x(p, j)} - \sum\limits_{j = 1}^{n^2}{x(q, j)} = \sum\limits_{j = 1}^{n^2}{x(q, j)} - \sum\limits_{j = 1}^{n^2}{x(t, j)},
+\\ \forall (p, q, t) \in \{(2k, 2k + 1, 2k + 2) | \forall k \in \{0, 1, ..., n - 2\}\} \cup \{(2n - 2, 2n - 1, 0)\}
+```
+
+### 2.3. Finding all solutions
+
+The model built above only gives us one solution. To find all remaining
+solutions, we use the following simple logic
+```python
+BEGIN THPTQG2025
+    initialize model M;
+    solve M;
+    S := solution of M;
+    WHILE (M is not infeasible)
+        add a constraint so that solution S no longer satisfies the model;
+        solve M;
+        S := solution of M;
+    END
+    Return S;
+END
+```
+
+Where the constraint used to exclude a solution is as follows
+```math
+\sum\limits_{(i, j) \in S} x(i, j) \leq 2n - 1
+```
+
+Where $S$ is a solution of the model, of the form $\{(i, j)|i \in \{0, 1, ..., n - 1\}; j \in \{1, 2, 3, ..., n^2\}; \text{position } i \text{ is filled with number } j \}$

--- a/data/posts/vi/logic-puzzle-modeling/logic-puzzle-modeling-a-puzzle-a-day.mdx
+++ b/data/posts/vi/logic-puzzle-modeling/logic-puzzle-modeling-a-puzzle-a-day.mdx
@@ -2,7 +2,7 @@
 title: Mô hình hóa câu đố A puzzle a day
 date: 2026-07-23
 series:
-  order: 6
+  order: 7
   title: Mô hình hóa các câu đố logic
 tags: [modeling, math, MILP, programing, python]
 summary: Mô hình hóa và giải câu đố A puzzle a day bằng phương pháp tối ưu tuyến tính hỗn hợp nguyên.


### PR DESCRIPTION
Translate the 6 vi-only posts (game collection, Gurobi install guide, A puzzle a day, Slitherlink, Love Letter, THPTQG 2025) into English so every post now has both locales.

Also fix "A puzzle a day" duplicating series.order 6 with Slitherlink, which put both posts at the same position in the logic puzzle modeling series listing.